### PR TITLE
:bug: Raise a ValueError if response fails

### DIFF
--- a/pydataxm/pydataxm.py
+++ b/pydataxm/pydataxm.py
@@ -140,6 +140,8 @@ class ReadDB(object):
                                 "Filter": self.filtros}
                 self.connection = requests.post(self.url, json=self.request)
                 data_json = json.loads(self.connection.content)
+                if "Message" in data_json.keys():
+                    raise ValueError(data_json.get("Message",None))
                 temporal_data = pd.json_normalize(data_json['Items'], 'DailyEntities', 'Date', sep='_')
                 if data is None:
                     data = temporal_data.copy()


### PR DESCRIPTION
Cuando se envía información erronea, como un mal formato en la fecha, la API responde con un mensaje de error; sin embargo, el código intenta procesar dicha respuesta. Cuando se intenta procesar una respuesta fallido, se levanta un error con pandas, pero no se brinda información sobre cual es el error en la solicitud, aunque la API si especifica eso.

Para brindar mayor información al usuario, se agregó una validación antes de intentar normalizar la respuesta. En el caso de que la respuesta de la API contenta la key "Message" se asume que es un error, por lo cual se levanta un ValueError especificando el mensaje que responde la API